### PR TITLE
add metadata to header of ad-hoc validation report view

### DIFF
--- a/src/app/views/data-quality-feedback/iati-info/iati-info.component.html
+++ b/src/app/views/data-quality-feedback/iati-info/iati-info.component.html
@@ -5,8 +5,8 @@
   <span *ngIf="validationReport.fileType">
     | Type: {{ validationReport.fileType }}</span
   >
-  <span *ngIf="documentInfo.validation_created">
+  <span *ngIf="documentInfo?.validation_created">
     | Report Generated:
-    {{ documentInfo.validation_created | date: "yyyy-MM-dd HH:mm (z)" }}</span
+    {{ documentInfo?.validation_created | date: "yyyy-MM-dd HH:mm (z)" }}</span
   >
 </p>

--- a/src/app/views/data-quality-feedback/main-report-info/main-report-info.component.html
+++ b/src/app/views/data-quality-feedback/main-report-info/main-report-info.component.html
@@ -1,1 +1,6 @@
-<h3><a [routerLink]="['/organisation', organisationInfo.name]" >{{ organisationInfo.title }}</a> - <a *ngIf="documentInfo.url" href="{{ documentInfo.url }}">{{ fileName() }}</a></h3>
+<h3>
+    <a *ngIf="organisationInfo" [routerLink]="['/organisation', organisationInfo.name]" >{{ organisationInfo.title }}</a> 
+    <span *ngIf="organisationInfo" > - </span>
+    <a *ngIf="documentInfo?.url" href="{{ documentInfo?.url }}">{{ fileName() }}</a>
+    <p *ngIf="!documentInfo?.url && fileNameString" >{{ fileNameString }}</p>  
+</h3>

--- a/src/app/views/data-quality-feedback/main-report-info/main-report-info.component.ts
+++ b/src/app/views/data-quality-feedback/main-report-info/main-report-info.component.ts
@@ -10,6 +10,7 @@ import { LogService } from './../../../core/logging/log.service';
 export class MainReportInfoComponent implements OnInit {
   @Input() documentInfo = {} as any;
   @Input() organisationInfo = {} as any;
+  @Input() fileNameString = '' as any;
 
   constructor(private logger: LogService) { }
 

--- a/src/app/views/data-quality-feedback/main/main.component.html
+++ b/src/app/views/data-quality-feedback/main/main.component.html
@@ -6,7 +6,7 @@
     <div class="col">
       <h2>File validation report</h2>
       <app-main-report-info *ngIf="documentInfo && organisationInfo" [documentInfo]="documentInfo" [organisationInfo]="organisationInfo"></app-main-report-info>
-      <app-iati-info *ngIf="documentInfo && validationReport" [documentInfo]="documentInfo" [validationReport]="validationReport"></app-iati-info>
+      <app-iati-info *ngIf="validationReport" [documentInfo]="documentInfo" [validationReport]="validationReport"></app-iati-info>
       <div *ngIf="fileStatus() === 'success'" class="file-success" role="alert">
         <h1>Success</h1>
       </div>

--- a/src/app/views/data-quality-feedback/main/main.component.html
+++ b/src/app/views/data-quality-feedback/main/main.component.html
@@ -5,8 +5,8 @@
   <div class="row alert alert-light">
     <div class="col">
       <h2>File validation report</h2>
-      <app-main-report-info *ngIf="documentInfo && organisationInfo" [documentInfo]="documentInfo" [organisationInfo]="organisationInfo"></app-main-report-info>
-      <app-iati-info *ngIf="validationReport" [documentInfo]="documentInfo" [validationReport]="validationReport"></app-iati-info>
+      <app-main-report-info [documentInfo]="documentInfo" [organisationInfo]="organisationInfo" [fileNameString]="fileName"></app-main-report-info>
+      <app-iati-info *ngIf="validationReport" [documentInfo]="documentInfo" [validationReport]="validationReport" ></app-iati-info>
       <div *ngIf="fileStatus() === 'success'" class="file-success" role="alert">
         <h1>Success</h1>
       </div>


### PR DESCRIPTION
Previously, we did not show metadata for an ad-hoc validation report.
Now, we show the IATI Version, File Type, and File Name for ad-hoc validation reports in the header, like the published files.

<img width="669" alt="image" src="https://user-images.githubusercontent.com/60047271/142911083-b7444dc3-e33d-4d75-ab58-d6f6902cde1e.png">


[Trello](https://trello.com/c/s7Qdk0Mu)
