### PR TITLE
use default locale available with angular like other date displays

### DIFF
--- a/src/app/organisation/shared/document.service.ts
+++ b/src/app/organisation/shared/document.service.ts
@@ -55,11 +55,7 @@ export class DocumentService {
     const { report, solrize_end, alv_end, alv_start, alv_error } = document;
 
     if (solrize_end) {
-      const formatedDate = formatDate(
-        solrize_end,
-        'yyyy-MM-dd HH:mm (z)',
-        new Intl.NumberFormat().resolvedOptions().locale
-      );
+      const formatedDate = formatDate(solrize_end, 'yyyy-MM-dd HH:mm (z)', 'en-US');
 
       return `${fileStatus === 'critical' && alv_end ? 'Partial' : 'Yes'} - ${formatedDate}`;
     }


### PR DESCRIPTION
[Trello](https://trello.com/c/9OGMt7TN)

## Previously
The organisation page would fail to display dates if the users locale was nl-NL (and potentially others)

## Now
We revert to previous display behaviour of always displaying this format `'yyyy-MM-dd HH:mm (z)'`